### PR TITLE
Expand audit logging to games

### DIFF
--- a/cassino_chines/app/Filament/Admin/Resources/AuditLogResource.php
+++ b/cassino_chines/app/Filament/Admin/Resources/AuditLogResource.php
@@ -16,9 +16,9 @@ class AuditLogResource extends Resource
     protected static ?string $model = AuditLog::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-check';
-    protected static ?string $navigationGroup = 'Sistema';
+    protected static ?string $navigationGroup = 'Auditoria';
     protected static ?string $modelLabel = 'Logs de Auditoria';
-    protected static ?string $navigationLabel = 'Logs de Auditoria';
+    protected static ?string $navigationLabel = 'Logs em Tempo Real';
     protected static ?int $navigationSort = 9999;
 
     public static function canViewAny(): bool
@@ -33,6 +33,7 @@ class AuditLogResource extends Resource
     public static function table(Tables\Table $table): Tables\Table
     {
         return $table
+            ->poll('5s')
             ->defaultSort('created_at', 'desc')
             ->columns([
                 TextColumn::make('created_at')->label('Data')->since()->sortable(),

--- a/cassino_chines/app/Filament/Admin/Resources/AuditLogResource/Pages/ListAuditLogs.php
+++ b/cassino_chines/app/Filament/Admin/Resources/AuditLogResource/Pages/ListAuditLogs.php
@@ -8,6 +8,7 @@ use Filament\Resources\Pages\ListRecords;
 class ListAuditLogs extends ListRecords
 {
     protected static string $resource = AuditLogResource::class;
+    protected static ?string $pollingInterval = '5s';
 
     protected function getHeaderActions(): array
     {

--- a/cassino_chines/app/Observers/ModelAuditObserver.php
+++ b/cassino_chines/app/Observers/ModelAuditObserver.php
@@ -95,6 +95,8 @@ class ModelAuditObserver
         $class = class_basename($model);
         return match ($class) {
             'ConfigPlayFiver' => 'games.rtp_limits',
+            'Game' => 'games.management',
+            'SpinConfigs' => 'games.spin_config',
             'Role', 'Permission' => 'auth.roles_permissions',
             'Gateway' => 'payments.gateway',
             'GamesKey' => 'games.keys',

--- a/cassino_chines/app/Providers/AppServiceProvider.php
+++ b/cassino_chines/app/Providers/AppServiceProvider.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Filament\Support\Assets\Js;
 use App\Observers\ModelAuditObserver;
-use App\Models\{Setting, SettingMail, Gateway, GamesKey, ConfigPlayFiver, Role, Permission, User, Vip, PostNotification, Mission, MissionDeposit};
+use App\Models\{Setting, SettingMail, Gateway, GamesKey, ConfigPlayFiver, Game, SpinConfigs, Role, Permission, User, Vip, PostNotification, Mission, MissionDeposit};
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -68,6 +68,8 @@ class AppServiceProvider extends ServiceProvider
             Gateway::class,
             GamesKey::class,
             ConfigPlayFiver::class,
+            Game::class,
+            SpinConfigs::class,
             Role::class,
             Permission::class,
             User::class,

--- a/cassino_chines/app/Providers/Filament/AdminPanelProvider.php
+++ b/cassino_chines/app/Providers/Filament/AdminPanelProvider.php
@@ -24,6 +24,7 @@ use App\Filament\Admin\Resources\GGRGamesDrakonResource;
 use App\Filament\Admin\Resources\GGRGamesResource;
 use App\Filament\Admin\Resources\GGRGamesFiverResource;
 use App\Filament\Admin\Resources\GGRGamesWorldSlotResource;
+use App\Filament\Admin\Resources\AuditLogResource;
 //use App\Filament\Admin\Resources\MissionResource;
 use App\Filament\Admin\Resources\MissionDepositResource;
 use App\Filament\Admin\Resources\MusicResource;
@@ -214,6 +215,12 @@ class AdminPanelProvider extends PanelProvider
                             ->url(url('/clear'), shouldOpenInNewTab: false)
                             ->icon('icon-limp')
                             ->visible(fn (): bool => auth()->user()->hasRole('admin')),
+                    ]),
+
+                // Auditoria
+                NavigationGroup::make('Auditoria')
+                    ->items([
+                        ...collect(AuditLogResource::getNavigationItems())->map(fn ($item) => $item->icon('heroicon-o-clipboard-document-check')),
                     ]),
             ]);
         })


### PR DESCRIPTION
## Summary
- Log changes to games and spin configurations
- Expose audit log list under new 'Auditoria' menu group
- Add real-time audit log tab with automatic refresh

## Testing
- `composer install` (fails: lcobucci/jwt 4.3.0 requires ext-sodium)
- `php artisan` (fails: Failed opening required 'vendor/autoload.php')


------
https://chatgpt.com/codex/tasks/task_e_68c1b68a8598832bbfb2eba3ac2ce104